### PR TITLE
Update service-fabric-cluster-creation-via-arm.md - fix the link to Ubuntu ARM template

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
@@ -112,7 +112,7 @@ az account set --subscription $subscriptionId
 Use the following command to create a cluster quickly, by specifying minimal parameters
 
 The template that is used is available on the [azure service fabric template samples : windows template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-Windows-1-NodeTypes-Secure-NSG)
- and [Ubuntu template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-ubuntu-1-NodeTypes-Secure)
+ and [Ubuntu template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-Ubuntu-1-NodeTypes-Secure)
 
 The commands below works for creating Windows and Linux clusters, you just need to specify the OS accordingly. The powershell/ CLI commands also outputs the certificate certificate in the specified in theCertificateOutputFolder. The command takes in other parameters like VM SKU as well.
 
@@ -222,7 +222,7 @@ If this is a CA signed certificate that you will end up using for other purposes
 
 #### Use the default 5 Node 1 nodetype template that ships in the module
 The template that is used is available on the [azure samples : windows template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-Windows-1-NodeTypes-Secure-NSG)
- and [Ubuntu template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-ubuntu-1-NodeTypes-Secure)
+ and [Ubuntu template](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-Ubuntu-1-NodeTypes-Secure)
 
 ```Powershell
 $resourceGroupLocation="westus"


### PR DESCRIPTION
This is a one-character fix to the URL for the Ubuntu SF ARM template on Github.

Old (incorrect) link: https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-ubuntu-1-NodeTypes-Secure

Updated link: https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/5-VM-Ubuntu-1-NodeTypes-Secure

The difference is 'u' vs 'U' in 'Ubuntu'